### PR TITLE
Patch for linux

### DIFF
--- a/src/bsaarchive.h
+++ b/src/bsaarchive.h
@@ -33,6 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <condition_variable>
 
 
 namespace BSA {

--- a/src/bsafolder.cpp
+++ b/src/bsafolder.cpp
@@ -35,7 +35,7 @@ Folder::Folder()
 {
   m_NameHash = calculateBSAHash(m_Name);
   m_FileCount = 0;
-  m_Offset = ULONG_MAX;
+  m_Offset = UINT_MAX;
 }
 
 

--- a/src/semaphore.h
+++ b/src/semaphore.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include <condition_variable>
 
 class Semaphore {
 public:


### PR DESCRIPTION
1 major change
- `#include <filesystem>`
- `createDirectory` -> `create_directory`
- changed `subDirName` -> `subDirPath` to indicate it is now a std::filesystem::path rather than a string.

2 header fixes
- `#include <thread>`
- `#include <condition_variable>` was missing

1 minor clang warning fix
- `m_Offset` should use `UINT_MAX` not `ULONG_MAX`
